### PR TITLE
Fix #25 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 # Allure Reporter
 
-Use this application to generate a printable report from the Allure result files. [Allure](http://allure.qatools.ru) is an [open-source framework](https://github.com/allure-framework/allure2) designed to create test execution reports that are clear to everyone in the team.
+Allure reporter will help you in the Test Case Automation strategy by generating Test Design and Test Run from the source code following a Test Case format, as well as JAMA Contour integration to report the executions.
+[Allure](http://allure.qatools.ru) is an [open-source framework](https://github.com/allure-framework/allure2) designed to create test execution reports that are clear to everyone in the team.
 
-Only Allure 2 compatible files, in json format, are supported.
+Supports Allure 1 (xml) and Allure 2 (json).
 
 You can find the application deployed by Travis at https://systelab.github.io/allure-reporter/
 

--- a/src/app/service/test-suite.service.ts
+++ b/src/app/service/test-suite.service.ts
@@ -53,10 +53,18 @@ export class TestSuiteService {
 		return testSuite;
 	}
 
+	private queryDirectChildren(parent, selector) {
+		const nodes = parent.querySelectorAll(selector);
+		const filteredNodes = [].slice.call(nodes)
+			.filter(n =>
+				n.parentNode.closest(selector) === parent.closest(selector)
+			);
+		return filteredNodes;
+	}
+
 	private parseSteps(parent: Element): Step[] {
 		const steps: Step[] = [];
-
-		const elementSteps = parent.getElementsByTagName('steps')[0].getElementsByTagName('step');
+		const elementSteps = this.queryDirectChildren(parent.getElementsByTagName('steps')[0], "step");
 
 		for (let i = 0; i < elementSteps.length; i++) {
 			const step: Step = {


### PR DESCRIPTION
Fix XML parser. The function getElementsByTagName("step") obtains all the steps in the tree and it's required to get only the first level children.