### PR TITLE
Fix issue #11

### DIFF
--- a/src/app/features/reporter/reporter-dialog.component.ts
+++ b/src/app/features/reporter/reporter-dialog.component.ts
@@ -11,8 +11,6 @@ import { Observable, throwError } from 'rxjs/index';
 import { format } from 'date-fns';
 import { TestSuiteService } from '../../service/test-suite.service';
 import { TestSuite } from '../../model/allure-test-case.model';
-import {createElementCssSelector} from '@angular/compiler';
-import {Validators} from '@angular/forms';
 
 export class ReporterDialogParameters extends SystelabModalContext {
 	public width = 550;


### PR DESCRIPTION
By means of another call to JAMA API, the application is able to get the document-key, allowing the tests to be referenced by Id when using the Allure tags. So far, the tests have to be referenced by the name and that functionality is kept in this version for compatibility with the projects that use that approach.