### PR TITLE
Switch from PUT operation to update a test case to a PATCH

### DIFF
--- a/src/app/features/reporter/reporter-dialog.component.ts
+++ b/src/app/features/reporter/reporter-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { DialogHeaderComponent, DialogRef, ModalComponent, SystelabModalContext } from 'systelab-components/widgets/modal';
-import { ProjectsService, RequestTestCycle, RequestTestRun, TestplansService, TestRun, TestrunsService, UsersService, ItemsService, TestRunDataListWrapper, AbstractitemsService, RequestItem } from '../../jama';
+import { ProjectsService, RequestTestCycle, RequestTestRun, TestplansService, TestRun, TestrunsService, UsersService, ItemsService, TestRunDataListWrapper, AbstractitemsService, RequestItem, RequestPatchOperation } from '../../jama';
 import { ToastrService } from 'ngx-toastr';
 import { ProjectComboBox } from '../../components/project-combobox.component';
 import { TestPlanComboBox } from '../../components/test-plan-combobox.component';
@@ -187,22 +187,31 @@ export class ReporterDialog implements ModalComponent<ReporterDialogParameters>,
 										'itemType':      itemTestCase.data.itemType,
 										'childItemType': itemTestCase.data.childItemType,
 										'location':      itemTestCase.data.location,
-										'fields':        {
-											'name': itemTestCase.data.fields['name'],
-											'description': this.testSuiteService.getDescription(suite.name),
-											'testCaseSteps': this.testSuiteService.getTestCaseStepsToUpdate(suite),
-											'priority': itemTestCase.data.fields['priority'],
-											'release': itemTestCase.data.fields['release'],
-											'status': itemTestCase.data.fields['status'],
-											[tcType] : itemTestCase.data.fields[tcType]
-										}
+										'fields':        {}
 									};
-									return this.itemsService.putItem(testCaseToUpdate, itemIDTestCase);
+
+									testCaseToUpdate.fields = JSON.parse(JSON.stringify(itemTestCase.data.fields));
+									testCaseToUpdate.fields['description'] = this.testSuiteService.getDescription(suite.name);
+									testCaseToUpdate.fields['testCaseSteps'] = this.testSuiteService.getTestCaseStepsToUpdate(suite);
+
+									var updateDescription : RequestPatchOperation = {
+										op : "replace",
+									    path : "/fields/description",
+										value : this.testSuiteService.getDescription(suite.name)};
+
+									var updateSteps : RequestPatchOperation = {
+									 op : "replace",
+									 path : "/fields/testCaseSteps",
+									 value : this.testSuiteService.getTestCaseStepsToUpdate(suite)
+									};
+
+									return this.itemsService.patchItem( [updateSteps, updateDescription], itemIDTestCase);
 								}));
 							}
 						)).subscribe();
 			});
 	}
+	
 
 	public doRun() {
 		if (this.selectedTestCycleId !== undefined) {


### PR DESCRIPTION
According to JAMA specifications, PATCH operation modifies only the referenced elements, leaving the other attributes unmodified. This matches better the intended goal of the method, rather than using a PUT and copying one by one all attributes.
See https://dev.jamasoftware.com/cookbook/#patch