### PR TITLE
Modify default URL to connect to JAMA must be updated to the new cloud instance

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  jamaUrl : 'https://jama.systelab.net/contour/rest/v1'
+  jamaUrl : 'https://werfen.jamacloud.com/rest/v1'
 };


### PR DESCRIPTION
Modify default URL to connect to JAMA must be updated to the new cloud instance