### PR TITLE
Fix #26

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,8 +21,6 @@
 		<help *ngIf="testSuites.length===0"></help>
 		<ng-container *ngIf="showSummary && showResults">
 			<test-summary-table [category]="'suite'" [categoryName]="'Test Suite'"></test-summary-table>
-			<test-summary-table [category]="'severity'" [categoryName]="'Severity'"></test-summary-table>
-			<test-summary-table [category]="'tag'" [categoryName]="'Tag'"></test-summary-table>
 		</ng-container>
 
 		<div *ngFor="let testSuite of testSuites">

--- a/src/app/features/report/summary/test-summary-table.component.html
+++ b/src/app/features/report/summary/test-summary-table.component.html
@@ -14,13 +14,13 @@
 				{{element.name}}
 			</div>
 			<div class="col-1 cell">
-				{{element.getPassedPercentage()}}
+				{{element.passed}} - {{element.getPassedPercentage()}}
 			</div>
 			<div class="col-1 cell">
-				{{element.getFailedPercentage()}}
+				{{element.failed}} - {{element.getFailedPercentage()}}
 			</div>
 			<div class="col-1 cell">
-				{{element.getOtherPercentage()}}
+				{{element.other}} - {{element.getOtherPercentage()}}
 			</div>
 			<div class="col-1 cell">{{element.total}}</div>
 		</div>


### PR DESCRIPTION
Fixing of issue #26 

- The 'Severity' and 'Tag' headers have been remove from the summary part
- Now the percentages in the 'Pass', 'Fail' and 'Other' columns (summary) are accompanied with the number of test with the corresponding status.