### PR TITLE
Avoid empty expected result

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -95,7 +95,9 @@ export class AppComponent {
 							const parser: DOMParser = new DOMParser();
 							const xmlDoc: Document = parser.parseFromString(e.target.result, 'text/xml');
 							const newTestSuite = this.testSuiteService.parseFromDocument(xmlDoc);
-							this.addTestSuite(newTestSuite);
+							if (newTestSuite.testCases.length > 0) {
+								this.addTestSuite(newTestSuite);
+							}
 						}
 					}
 				};

--- a/src/app/service/test-case.service.ts
+++ b/src/app/service/test-case.service.ts
@@ -91,7 +91,7 @@ export class TestCaseService {
 		const step: Step = {
 			name:           '',
 			action:         isActionResult ? this.addStepSeparator(stepName, level) : undefined,
-			expectedResult: isActionResult ? undefined : stepName,
+			expectedResult: isActionResult ? undefined : stepName || elementStep.expectedResult,
 			status:         elementStep.status,
 			statusDetails:  undefined,
 			stage:          '',

--- a/src/app/service/test-suite.service.ts
+++ b/src/app/service/test-suite.service.ts
@@ -51,7 +51,13 @@ export class TestSuiteService {
 					testSuite.actualResults = label.value;
 				}
 			}
-			this.addTestCaseToTestSuite(testCase, testSuite);
+
+			const skippedTest = elementTestcases[i].getElementsByTagName('message').length > 0 &&
+				elementTestcases[i].getElementsByTagName('message')[0].childNodes[0].nodeValue === 'This test was ignored';
+
+			if (!skippedTest) {
+				this.addTestCaseToTestSuite(testCase, testSuite);
+			}
 		}
 		if (!testSuite.id) {
 			testSuite.id = xmlDocument.getElementsByTagName('name')[0].childNodes[0].nodeValue;


### PR DESCRIPTION
Sometimes the expected results are emptied when the tests are organized using nested describes.
Other case are skipped tests showed with skipped results empty that we don't want in allure reports.

Issue: https://github.com/systelab/allure-reporter/issues/124

![image](https://github.com/user-attachments/assets/d59eae32-59d6-4d7a-9240-9303ecf2f695)
