### PR TITLE
fix-26.2 add total line with same format and percentages

### DIFF
--- a/src/app/features/report/summary/test-summary-table.component.html
+++ b/src/app/features/report/summary/test-summary-table.component.html
@@ -33,6 +33,27 @@
 			</div>
 			<div class="col-1 cell">{{element.total}}</div>
 		</div>
+
+		<div *ngIf="elements.length>1" class="row">
+			<div class="col-8 cell">
+				<b>TOTAL:</b>
+			</div>
+			<div class="col-1 cell">
+				<b>{{this.getAllPassed()}}</b>
+				<div>{{this.getAllPassedPercentage()}}</div>
+			</div>
+			<div class="col-1 cell">
+				<b>{{this.getAllFailed()}}</b>
+				<div>{{this.getAllFailedPercentage()}}</div>
+			</div>
+			<div class="col-1 cell">
+				<b>{{this.getAllOther()}}</b>
+				<div>{{this.getAllOtherPercentage()}}</div>
+			</div>
+			<div class="col-1 cell">
+				<b>{{this.getAllTotal()}}</b>
+			</div>
+		</div>
 	</div>
 </div>
 

--- a/src/app/features/report/summary/test-summary-table.component.ts
+++ b/src/app/features/report/summary/test-summary-table.component.ts
@@ -62,6 +62,34 @@ export class TestSummaryTableComponent {
 		this.ref.detectChanges();
 	}
 
+	public getAllPassed() {
+		return this.elements.reduce((sum, current) => sum + current.passed, 0);
+	}
+
+	public getAllFailed() {
+		return this.elements.reduce((sum, current) => sum + current.failed, 0);
+	}
+
+	public getAllOther() {
+		return this.elements.reduce((sum, current) => sum + current.other, 0);
+	}
+
+	public getAllTotal() {
+		return this.elements.reduce((sum, current) => sum + current.total, 0);
+	}
+
+	public getAllPassedPercentage() {
+		return Math.round(this.getAllPassed() * 100 / this.getAllTotal()) + '%';
+	}
+
+	public getAllFailedPercentage() {
+		return Math.round(this.getAllFailed() * 100 / this.getAllTotal()) + '%';
+	}
+
+	public getAllOtherPercentage() {
+		return Math.round(this.getAllOther() * 100 / this.getAllTotal()) + '%';
+	}
+
 	private createOrUpdateElement(test: TestCase): void {
 		const elementName = this.getElementName(test);
 


### PR DESCRIPTION
Fixing of issue https://github.com/systelab/allure-reporter/issues/26 (continued)

Now a TOTAL line is added when the summary is composed by a list of several (more than one) test suites, the format is the same from the lines above and the percentages relative to the great total are also included:

<img width="1886" height="502" alt="image" src="https://github.com/user-attachments/assets/f9e79086-cf00-4aa4-8e4d-979624a6284a" />

(..)

<img width="1789" height="299" alt="image" src="https://github.com/user-attachments/assets/a83dc368-23a4-47fc-bc55-15f4bda7499b" />

No TOTAL line would be displayed in this cases:
* Only one test suite is in the summary:
<img width="1579" height="354" alt="image" src="https://github.com/user-attachments/assets/7f121d1d-ab2e-4ffa-a036-4e1f2cc0304e" />

* No test suites, all test cases are grouped in one line:

<img width="1462" height="309" alt="image" src="https://github.com/user-attachments/assets/0fae0ae1-d983-4ab0-b781-4e1303fe0b0b" />
