### PR TITLE
Include in User Info the .NET and retry limitations

### DIFF
--- a/src/assets/user_info.md
+++ b/src/assets/user_info.md
@@ -1,18 +1,20 @@
 ## Relevant Information for Users
 ---
-### Limitations in result reporting
+### Limitations: 
 
-If an unhandled exception occurs during test case execution, some of the subsequent steps may not be executed (and therefore not reported).
+* __Result reporting:__
 
-The absence of this information could cause some test cases to appear as passed even though specific steps were not executed. This is neither valid nor acceptable, as the test case design would be incomplete and the test case result inaccurate.
-For this reason, it is essential to ensure that the execution has completed successfully without exceptions before generating the report. The automation code must implement mechanisms to avoid generating partial results and to detect incomplete executions.
+    If an unhandled exception occurs during test case execution, some of the subsequent steps may not be executed (and therefore not reported).
 
-The use of the new “Upload Step Results Mode” option serves as a mitigation for this abnormal and undesired behavior as it checks the number of steps and exact content. 
+    The absence of this information could cause some test cases to appear as passed even though specific steps were not executed. This is neither valid nor acceptable, as the test case design would be incomplete and the test case result inaccurate.
+    For this reason, it is essential to ensure that the execution has completed successfully without exceptions before generating the report. The automation code must implement mechanisms to avoid generating partial results and to detect incomplete executions.
 
-#### For .NET results (using NUnit)
+    The use of the new “Upload Step Results Mode” option serves as a mitigation for this abnormal and undesired behavior as it checks the number of steps and exact content. 
 
-The test header will only display the string specified in the **tmslink tag**.
+* __.NET results (using NUnit):__
 
-#### Retries of the same Test Case
+    The test header will only display the string specified in the **tmslink tag**.
 
-The reporting of several retries of the same Test Case is not supported using the JSON format, as it is interpreted incorrectly (each retry is merged when the last one should be reported)
+* __Retries of the same Test Case:__
+
+    The reporting of several retries of the same Test Case is not supported using the JSON format, as it is interpreted incorrectly (each retry is merged when the last one should be reported)


### PR DESCRIPTION
In this PR we are going to document all the limitations/explanations to be detailed in the main page (in the Relevant information for Users section)