### PR TITLE
Added counters for TestCase summarizing and updated Summary Table - issue #26

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,7 +27,7 @@
       <help></help>
     }
     @if (showSummary && showResults) {
-      <test-summary-table [category]="'suite'" [categoryName]="'Test Suite'"></test-summary-table>
+      <test-summary-table [category]="'testCase'" [categoryName]="'Test Case'"></test-summary-table>
     }
 
     @for (testSuite of testSuites; track testSuite) {

--- a/src/app/features/report/summary/test-summary-table.component.html
+++ b/src/app/features/report/summary/test-summary-table.component.html
@@ -3,11 +3,11 @@
     <h2 class="mb-2 mt-4">Test Summary by {{categoryName}}</h2>
     <div class="container mt-3">
       <div class="row mb-0">
-        <div class="col-8 header-cell">{{categoryName}}</div>
-        <div class="col-1 header-cell">Pass</div>
-        <div class="col-1 header-cell">Fail</div>
-        <div class="col-1 header-cell">Other</div>
-        <div class="col-1 header-cell">Total</div>
+        <div class="col-8 header-cell"><b>{{categoryName}}</b></div>
+        <div class="col-1 header-cell"><b>Pass</b></div>
+        <div class="col-1 header-cell"><b>Fail</b></div>
+        <div class="col-1 header-cell"><b>Other</b></div>
+        <div class="col-1 header-cell"><b>Total</b></div>
       </div>
       @for (element of elements; track element) {
         <div class="row mb-0">
@@ -15,24 +15,15 @@
             {{element.name}}
           </div>
           <div class="col-1 cell">
-            <b>{{element.passed}}</b>
-            <div >
-              {{element.getPassedPercentage()}}
-            </div>
+              {{element.TcPassed}}
           </div>
           <div class="col-1 cell">
-            <b>{{element.failed}}</b>
-            <div>
-              {{element.getFailedPercentage()}}
-            </div>
+              {{element.TcFailed}}
           </div>
           <div class="col-1 cell">
-            <b>{{element.other}}</b>
-            <div>
-              {{element.getOtherPercentage()}}
-            </div>
+              {{element.TcOther}}
           </div>
-          <div class="col-1 cell">{{element.total}}</div>
+          <div class="col-1 cell">{{element.TcTotal}} </div>
         </div>
       }
       @if (elements.length>1) {

--- a/src/app/features/report/summary/test-summary-table.component.ts
+++ b/src/app/features/report/summary/test-summary-table.component.ts
@@ -6,6 +6,11 @@ export class Element {
 	public passed = 0;
 	public failed = 0;
 	public other = 0;
+	// new Test Case counters
+	public TcTotal = 0;
+	public TcPassed = 0;
+	public TcFailed = 0;
+	public TcOther = 0;
 
 	public constructor(public name: string) {
 	}
@@ -19,6 +24,11 @@ export class Element {
 		} else {
 			this.other++;
 		}
+		// Test Case counters update
+		this.TcTotal = 1;
+		this.TcPassed = this.passed === this.total ? 1 : 0;
+		this.TcFailed = this.TcPassed === 0 && this.failed > 0 ? 1 : 0;
+		this.TcOther = this.TcPassed === 0 && this.TcFailed === 0 && this.other > 0 ? 1 : 0;
 	}
 
 	public getPassedPercentage() {
@@ -63,31 +73,31 @@ export class TestSummaryTableComponent {
 	}
 
 	public getAllPassed() {
-		return this.elements.reduce((sum, current) => sum + current.passed, 0);
+		return this.elements.reduce((sum, current) => sum + current.TcPassed, 0);
 	}
 
 	public getAllFailed() {
-		return this.elements.reduce((sum, current) => sum + current.failed, 0);
+		return this.elements.reduce((sum, current) => sum + current.TcFailed, 0);
 	}
 
 	public getAllOther() {
-		return this.elements.reduce((sum, current) => sum + current.other, 0);
+		return this.elements.reduce((sum, current) => sum + current.TcOther, 0);
 	}
 
 	public getAllTotal() {
-		return this.elements.reduce((sum, current) => sum + current.total, 0);
+		return this.elements.reduce((sum, current) => sum + current.TcTotal, 0);
 	}
 
 	public getAllPassedPercentage() {
-		return Math.round(this.getAllPassed() * 100 / this.getAllTotal()) + '%';
+		return Math.round(this.getAllPassed() * 10000 / this.getAllTotal()) / 100 + '%';
 	}
 
 	public getAllFailedPercentage() {
-		return Math.round(this.getAllFailed() * 100 / this.getAllTotal()) + '%';
+		return Math.round(this.getAllFailed() * 10000 / this.getAllTotal()) / 100 + '%';
 	}
 
 	public getAllOtherPercentage() {
-		return Math.round(this.getAllOther() * 100 / this.getAllTotal()) + '%';
+		return Math.round(this.getAllOther() * 10000 / this.getAllTotal()) / 100 + '%';
 	}
 
 	private createOrUpdateElement(test: TestCase): void {
@@ -102,7 +112,10 @@ export class TestSummaryTableComponent {
 	}
 
 	private getElementName(test: TestCase): string {
-		const label = test.labels.find((l) => l.name === this.category);
-		return label ? label.value : '';
+		// the file is json -> the Test Case name is in the links array
+		const link = test.links.find((l) => l.type === 'tms');
+		// the file is xml -> the Test Case name is in the labels array
+		const label = test.labels.find((l) => l.name === 'tms');
+		return label ? label.value : link.name;
 	}
 }


### PR DESCRIPTION
This PR aims to cover the following statements from issue #26 :

> v.4.0. The expected is to leave just a Test Summary row with TOTALS of Test Cases in the report: including Total of Pass, %Pass, Total of Failed, %Fail and Total number of TCs.
> 
> Please remove any reference to the Suites of count by suite or action.

Here is a sample preview:
<img width="975" height="378" alt="image" src="https://github.com/user-attachments/assets/2923640b-212d-45db-96cc-52b06978fef0" />

Now the table is populated with the real Test Case elements and the counters and percentages have been grouped to reflect the own test case status. Depending on the file format (json/xml) the test case name is retrieved from a different place (links array in json files, labels array in xml files) but the rest of the processing is the same for both file types.