### PR TITLE
issue-147: drop default block for mapStatusToTestRunStep (strict mode)

### DIFF
--- a/src/app/features/reporter/reporter-dialog.component.ts
+++ b/src/app/features/reporter/reporter-dialog.component.ts
@@ -498,9 +498,6 @@ export class ReporterDialog implements ModalComponent<ReporterDialogParameters>,
 						case 'failed':
 							step.status = 'FAILED';
 							break;
-						default:
-							step.status = suiteStep.status.toUpperCase();
-							break;
 					}
 				}
 				return step;


### PR DESCRIPTION
The aim of this PR is to revert a change that was causing this undesirable scenario:

STEP BY STEP:
si l'estat del resultat global es PENDING i té algún step amb estat pending --> 
EXPECTED: es reporta a Jama com In Progress i l'estat de l'step "not run". 
CURRENT: No es reporta, dona error